### PR TITLE
Updated FluentAssertions to 6.4.0 and unify System.IO.Abstractions version variable

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -31,7 +31,7 @@
                       IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"
                       PrivateAssets="all" />
     <PackageReference Update="Divergic.Logging.Xunit"                   Version="4.0.0" />
-    <PackageReference Update="FluentAssertions"                         Version="6.3.0" />
+    <PackageReference Update="FluentAssertions"                         Version="6.4.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                   Version="17.0.0" />
     <PackageReference Update="System.IO.Abstractions.TestingHelpers"    Version="$(SystemIOAbstractionsVersion)" />
     <PackageReference Update="xunit"                                    Version="2.4.1" />

--- a/Packages.props
+++ b/Packages.props
@@ -2,6 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <DotNetPackageVersion>6.0.0</DotNetPackageVersion>
+    <SystemIOAbstractionsVersion>16.1.4</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,7 +24,7 @@
     <PackageReference Update="Serilog.Sinks.Console"                    Version="4.0.1" />
     <PackageReference Update="Serilog.Sinks.File"                       Version="5.0.0" />
     <PackageReference Update="Serilog.Sinks.Trace"                      Version="3.0.0" />
-    <PackageReference Update="System.IO.Abstractions"                   Version="16.1.4" />
+    <PackageReference Update="System.IO.Abstractions"                   Version="$(SystemIOAbstractionsVersion)" />
 
     <!-- Test dependencies -->
     <PackageReference Update="coverlet.collector"                       Version="3.1.0"
@@ -32,7 +33,7 @@
     <PackageReference Update="Divergic.Logging.Xunit"                   Version="4.0.0" />
     <PackageReference Update="FluentAssertions"                         Version="6.3.0" />
     <PackageReference Update="Microsoft.NET.Test.Sdk"                   Version="17.0.0" />
-    <PackageReference Update="System.IO.Abstractions.TestingHelpers"    Version="16.1.4" />
+    <PackageReference Update="System.IO.Abstractions.TestingHelpers"    Version="$(SystemIOAbstractionsVersion)" />
     <PackageReference Update="xunit"                                    Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio"                Version="2.4.3"
                       IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive"


### PR DESCRIPTION
- This change updates FluentAssertions to [6.4.0](https://github.com/fluentassertions/fluentassertions/releases/tag/6.4.0).
- This change unifies the System.IO.Abstractions packages under the same version variable.