### PR TITLE
Updated CsWin32 and other dependencies

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -18,7 +18,7 @@
     <PackageReference Update="Microsoft.Extensions.DependencyInjection" Version="$(DotNetPackageVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging"             Version="$(DotNetPackageVersion)" />
     <PackageReference Update="Microsoft.Extensions.Logging.Debug"       Version="$(DotNetPackageVersion)" />
-    <PackageReference Update="Microsoft.Windows.CsWin32"                Version="0.1.619-beta" />
+    <PackageReference Update="Microsoft.Windows.CsWin32"                Version="0.1.635-beta" />
     <PackageReference Update="Serilog"                                  Version="2.10.0" />
     <PackageReference Update="Serilog.Extensions.Logging"               Version="3.1.0" />
     <PackageReference Update="Serilog.Sinks.Console"                    Version="4.0.1" />

--- a/Packages.props
+++ b/Packages.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <DotNetPackageVersion>6.0.0</DotNetPackageVersion>
-    <SystemIOAbstractionsVersion>16.1.16</SystemIOAbstractionsVersion>
+    <SystemIOAbstractionsVersion>16.1.20</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StartMenuCleaner/NativeMethods.txt
+++ b/src/StartMenuCleaner/NativeMethods.txt
@@ -2,4 +2,4 @@ IPersistFile
 IShellLinkW
 MAX_PATH
 ShellLink
-STGM_READ
+STGM

--- a/src/StartMenuCleaner/Utils/CsWin32ShortcutHandler.cs
+++ b/src/StartMenuCleaner/Utils/CsWin32ShortcutHandler.cs
@@ -16,11 +16,7 @@ internal class CsWin32ShortcutHandler : IFileShortcutHandler
             throw new NotSupportedException($"{nameof(ResolveTarget)} is only supported on Windows 5.1.2600+.");
         }
 
-        // See the following issues for current status and new advice:
-        // https://github.com/microsoft/CsWin32/issues/453
-        // https://github.com/microsoft/CsWin32/discussions/323
-        IPersistFile shellLink = (IPersistFile)(Activator.CreateInstance(Type.GetTypeFromCLSID(typeof(ShellLink).GUID, throwOnError: true)!)
-            ?? throw new InvalidOperationException("Failed to create an instance of ShellLink"));
+        IPersistFile shellLink = (IPersistFile)new ShellLink();
 
         fixed (char* shortcutFilePathPcwstr = shortcutPath)
         {

--- a/src/StartMenuCleaner/Utils/CsWin32ShortcutHandler.cs
+++ b/src/StartMenuCleaner/Utils/CsWin32ShortcutHandler.cs
@@ -4,6 +4,7 @@ using System;
 using Windows.Win32;
 using Windows.Win32.Storage.FileSystem;
 using Windows.Win32.System.Com;
+using Windows.Win32.System.Com.StructuredStorage;
 using Windows.Win32.UI.Shell;
 
 internal class CsWin32ShortcutHandler : IFileShortcutHandler
@@ -23,7 +24,7 @@ internal class CsWin32ShortcutHandler : IFileShortcutHandler
 
         fixed (char* shortcutFilePathPcwstr = shortcutPath)
         {
-            shellLink.Load(shortcutFilePathPcwstr, PInvoke.STGM_READ);
+            shellLink.Load(shortcutFilePathPcwstr, (uint)STGM.STGM_READ);
         }
 
         Span<char> szShortcutTargetPath = stackalloc char[(int)PInvoke.MAX_PATH];


### PR DESCRIPTION
- Updated CsWin32 to 0.1.635-beta
  - In CsWin32 0.1.635-beta, the `ShellLink` class became cocreatable, which allows me to restore my original method of creating a `ShellLink`. See https://github.com/microsoft/CsWin32/issues/453.
- Update System.IO.Abstractions to 16.1.20