### PR TITLE
Update System.IO.Abstractions to 17.0.3

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <DotNetPackageVersion>6.0.0</DotNetPackageVersion>
-    <SystemIOAbstractionsVersion>16.1.25</SystemIOAbstractionsVersion>
+    <SystemIOAbstractionsVersion>17.0.3</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/StartMenuCleaner.TestLibrary/Extensions/MockFileSystemExtensions.cs
+++ b/src/StartMenuCleaner.TestLibrary/Extensions/MockFileSystemExtensions.cs
@@ -1,0 +1,22 @@
+namespace StartMenuCleaner.TestLibrary;
+
+using System;
+using System.IO.Abstractions.TestingHelpers;
+
+/// <summary>
+/// Class MockFileSystemExtensions.
+/// </summary>
+public static class MockFileSystemExtensions
+{
+    /// <summary>
+    /// Adds an empty file to the mock file system.
+    /// </summary>
+    /// <param name="mockFileSystem">The mock file system.</param>
+    /// <param name="path">The path.</param>
+    public static void AddEmptyFile(this MockFileSystem mockFileSystem, string path)
+    {
+        ArgumentNullException.ThrowIfNull(mockFileSystem);
+
+        mockFileSystem.AddFile(path, new MockFileData(Array.Empty<byte>()));
+    }
+}

--- a/src/StartMenuCleaner.TestLibrary/MockFileSystemComposer.cs
+++ b/src/StartMenuCleaner.TestLibrary/MockFileSystemComposer.cs
@@ -86,7 +86,7 @@ public class MockFileSystemComposer
         }
         else
         {
-            this.FileSystem.AddFile(filePath, MockFileData.NullObject);
+            this.FileSystem.AddEmptyFile(filePath);
         }
     }
 


### PR DESCRIPTION
  - This change updates System.IO.Abstractions to 17.0.3, which contains a breaking changing making `MockFileData.NullObject` internal. I've replaced the behavior with an `AddEmptyFile` extension method.