### PR TITLE
Update packages to latest

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.4.240",
+      "version": "3.5.119",
       "commands": [
         "nbgv"
       ]

--- a/Packages.props
+++ b/Packages.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <DotNetPackageVersion>6.0.0</DotNetPackageVersion>
+    <DotNetPackageVersion>7.0.0</DotNetPackageVersion>
     <SystemIOAbstractionsVersion>17.2.3</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
@@ -32,7 +32,7 @@
                       PrivateAssets="all" />
     <PackageReference Update="Divergic.Logging.Xunit"                   Version="4.2.0" />
     <PackageReference Update="FluentAssertions"                         Version="6.8.0" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk"                   Version="17.3.2" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk"                   Version="17.4.0" />
     <PackageReference Update="System.IO.Abstractions.TestingHelpers"    Version="$(SystemIOAbstractionsVersion)" />
     <PackageReference Update="xunit"                                    Version="2.4.2" />
     <PackageReference Update="xunit.runner.visualstudio"                Version="2.4.5"


### PR DESCRIPTION
- Updates the following packages:
  - `Microsoft.Extensions.DependencyInjection`: `6.0.0` to `7.0.0`.
  - `Microsoft.Extensions.Logging`: `6.0.0` to `7.0.0`.
  - `Microsoft.Extensions.Logging.Debug`: `6.0.0` to `7.0.0`.
  - `Microsoft.NET.Test.Sdk`: `17.3.2` to `17.4.0`.
- Also updated the `nbgv` tool to `3.5.119`.