### PR TITLE
Disable `dotnet format` until bugs are fixed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -63,6 +63,9 @@ dotnet_diagnostic.IDE0058.severity = suggestion
 # IDE0059: Remove unnecessary value assignment
 dotnet_diagnostic.IDE0059.severity = suggestion
 
+# IDE0270: Null check can be simplified
+dotnet_diagnostic.IDE0270.severity = suggestion
+
 #### Naming styles ####
 
 # Naming rules

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,9 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      - name: DotNet Format
-        run: dotnet format --no-restore --verify-no-changes
+      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
+      # - name: DotNet Format
+      #   run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore

--- a/test/StartMenuCleaner.TestLibrary/EmbeddedResourceHelper.cs
+++ b/test/StartMenuCleaner.TestLibrary/EmbeddedResourceHelper.cs
@@ -61,16 +61,8 @@ public class EmbeddedResourceHelper
     /// <returns><see cref="ManifestResourceInfo"/>.</returns>
     /// <exception cref="ArgumentException"></exception>
     public ManifestResourceInfo GetResourceInfo(string embeddedResourcePath)
-    {
-        ManifestResourceInfo? resourceInfo = this.resourceAssembly.GetManifestResourceInfo(embeddedResourcePath);
-
-        if (resourceInfo is null)
-        {
-            throw new ArgumentException($"The embedded resource could not be found in {this.resourceAssembly.FullName}: '{embeddedResourcePath}'.", nameof(embeddedResourcePath));
-        }
-
-        return resourceInfo;
-    }
+        => this.resourceAssembly.GetManifestResourceInfo(embeddedResourcePath)
+            ?? throw new ArgumentException($"The embedded resource could not be found in {this.resourceAssembly.FullName}: '{embeddedResourcePath}'.", nameof(embeddedResourcePath));
 
     /// <summary>
     /// Loads the embedded resource  to a stream.
@@ -79,16 +71,8 @@ public class EmbeddedResourceHelper
     /// <returns><see cref="Stream"/>.</returns>
     /// <exception cref="ArgumentException"></exception>
     public Stream LoadStream(string embeddedResourcePath)
-    {
-        Stream? embeddedResourceStream = this.resourceAssembly.GetManifestResourceStream(embeddedResourcePath);
-
-        if (embeddedResourceStream is null)
-        {
-            throw new ArgumentException($"The embedded resource could not be found in {this.resourceAssembly.FullName}: '{embeddedResourcePath}'.", nameof(embeddedResourcePath));
-        }
-
-        return embeddedResourceStream;
-    }
+        => this.resourceAssembly.GetManifestResourceStream(embeddedResourcePath)
+            ?? throw new ArgumentException($"The embedded resource could not be found in {this.resourceAssembly.FullName}: '{embeddedResourcePath}'.", nameof(embeddedResourcePath));
 
     /// <summary>
     /// Copies the embedded resource to the file system.


### PR DESCRIPTION
This change disables `dotnet format` until the issues in .NET SDK 7.0.200 are fixed.