### PR TITLE
Update dependencies

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "nbgv": {
-      "version": "3.5.119",
+      "version": "3.6.128",
       "commands": [
         "nbgv"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SystemIOAbstractionsVersion>19.2.4</SystemIOAbstractionsVersion>
+    <SystemIOAbstractionsVersion>19.2.18</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -12,7 +12,7 @@
     -->
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.5.119" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.128" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Bumps Nerdbank.GitVersioning and nbgv from 3.5.119 to 3.6.128.
Bumps System.IO.Abstractions and System.IO.Abstractions.TestingHelpers from 19.2.4 to 19.2.18.