### PR TITLE
Enable GenerateDocumentationFile for tests projects

### DIFF
--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -31,7 +31,6 @@
 
     <!-- Generate XML documentation for not test projects. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <GenerateDocumentationFile Condition="$(MSBuildProjectName.EndsWith('.Tests'))">false</GenerateDocumentationFile>
 
     <!-- Normalize file paths on CI builds. -->
     <ContinuousIntegrationBuild>$(IsCIBuild)</ContinuousIntegrationBuild>

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -1,0 +1,11 @@
+root = false
+
+# Project specific settings
+
+[*.cs]
+
+# CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+
+# CA1707: Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = none

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+
+  <PropertyGroup>
+    <!-- For some reason, the SDK on Windows fails to respect the suppressions in the .editorconfig. -->
+    <NoWarn>$(NoWarn);CS1591;CA1707</NoWarn>
+  </PropertyGroup>
+
+</Project>

--- a/test/StartMenuCleaner.Tests/Extensions/IOExtensionsTests.cs
+++ b/test/StartMenuCleaner.Tests/Extensions/IOExtensionsTests.cs
@@ -3,7 +3,6 @@
 using System.IO.Abstractions.TestingHelpers;
 
 using StartMenuCleaner.Extensions;
-using StartMenuCleaner.TestLibrary.Extensions;
 
 public class IOExtensionsTests
 {


### PR DESCRIPTION
* The .NET 7.0 SDK 7.0.400+ added new requirements for some analyzers requiring `GenerateDocumentationFile`.
* Fix analyzer warnings.