### PR TITLE
Re-enable `dotnet format` in build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,10 +41,6 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
-      # - name: DotNet Format
-      #   run: dotnet format --no-restore --verify-no-changes
-
       - name: Build
         run: dotnet build --configuration Release --no-restore
 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -23,9 +23,8 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
 
-      # Disable until https://github.com/dotnet/format/issues/1800 is fixed.
-      # - name: DotNet Format
-      #   run: dotnet format --no-restore --verify-no-changes
+      - name: DotNet Format
+        run: dotnet format --no-restore --verify-no-changes
 
       - name: Build
         run: dotnet build --configuration Release --no-restore


### PR DESCRIPTION
This change re-enables `dotnet format` checks in PR builds and removes the check on CI builds.