### PR TITLE
Trying a fix for NuGet publishing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -71,6 +71,8 @@ jobs:
     name: 'Release StartMenuCleaner'
     runs-on: windows-latest
     needs: build
+    permissions:
+      packages: write
 
     env:
       PACKAGE_VERSION: ${{ needs.build.outputs.package_version }}


### PR DESCRIPTION
As usual, the silly GitHub actions permissions model appears to have changed. Trying a fix documented [here](https://docs.github.com/en/actions/security-guides/automatic-token-authentication) to grant the token permissions to push NuGet packages.