### PR TITLE
Update packages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <SystemIOAbstractionsVersion>19.2.18</SystemIOAbstractionsVersion>
+    <SystemIOAbstractionsVersion>19.2.69</SystemIOAbstractionsVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -21,7 +21,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection"          Version="$(DotNetPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging"                      Version="$(DotNetPackageVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug"                Version="$(DotNetPackageVersion)" />
-    <PackageVersion Include="Microsoft.Windows.CsWin32"                         Version="0.2.206-beta" />
+    <PackageVersion Include="Microsoft.Windows.CsWin32"                         Version="0.3.46-beta" />
     <PackageVersion Include="Serilog"                                           Version="3.0.1" />
     <PackageVersion Include="Serilog.Extensions.Logging"                        Version="7.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console"                             Version="4.1.0" />


### PR DESCRIPTION
This change updates Microsoft.Windows.CsWin32 to 0.3.46-beta and System.IO.Abstractions to 19.2.69.