### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -206,6 +206,9 @@ csharp_style_expression_bodied_operators = when_on_single_line
 # IDE0090: Use 'new(...)'
 csharp_style_implicit_object_creation_when_type_is_apparent = true
 
+# IDE0290: Use Primary Constructors
+csharp_style_prefer_primary_constructors = false
+
 csharp_indent_labels = one_less_than_current
 csharp_space_around_binary_operators = before_and_after
 csharp_using_directive_placement = inside_namespace

--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -6,7 +6,7 @@ runs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.x
+        dotnet-version: 8.x
 
     - name: Install .NET tools
       shell: pwsh

--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -55,7 +55,7 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: codecov
-          directory: __test-results
+          directory: __artifacts/test-results
           fail_ci_if_error: true
           verbose: true
 
@@ -63,10 +63,10 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: output
-          path: __output
+          path: __artifacts/bin
 
       - name: Upload package artifact
         uses: actions/upload-artifact@v3
         with:
           name: packages
-          path: __packages
+          path: __artifacts/package

--- a/.github/workflows/workflow_release.yml
+++ b/.github/workflows/workflow_release.yml
@@ -25,10 +25,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: packages
-          path: __packages
+          path: __artifacts/package
 
       - name: Configure GitHub NuGet registry
         run: nuget sources add -name github -source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json -username ${{ github.repository_owner }} -password ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push ${{ inputs.package-version }} to GitHub package registry
-        run: nuget push __packages\NuGet\Release\*.nupkg -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source github
+        run: nuget push __artifacts/package/release/*.nupkg -ApiKey ${{ secrets.GITHUB_TOKEN }} -Source github

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}__output/Debug/AnyCPU/StartMenuCleaner/net7.0/StartMenuCleaner.dll",
+            "program": "${workspaceFolder}__artifacts/bin/StartMenuCleaner/debug/StartMenuCleaner.dll",
             "args": [],
             "cwd": "${workspaceFolder}",
             // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,11 +3,9 @@
   <PropertyGroup>
     <RepoRootPath>$(MSBuildThisFileDirectory)</RepoRootPath>
     <SourceRootPath>$(RepoRootPath)src</SourceRootPath>
-    <CentralBuildOutputPath>$(RepoRootPath)</CentralBuildOutputPath>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <ArtifactsPath>$(RepoRootPath)__artifacts</ArtifactsPath>
   </PropertyGroup>
 
   <Import Project="$(MSBuildThisFileDirectory)\eng\Defaults.props" />
-
-  <!-- Import the CentralBuildOutput SDK. -->
-  <Sdk Name="Treasure.Build.CentralBuildOutput" />
 </Project>

--- a/eng/DotNetAnalyzers.props
+++ b/eng/DotNetAnalyzers.props
@@ -8,7 +8,7 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-    <AnalysisLevel>7.0</AnalysisLevel>
+    <AnalysisLevel>8.0</AnalysisLevel>
   </PropertyGroup>
 
 </Project>

--- a/eng/DotNetDefaults.props
+++ b/eng/DotNetDefaults.props
@@ -10,7 +10,7 @@
     <!-- Sets the C# language version:
       https://docs.microsoft.com/dotnet/csharp/language-reference/configure-language-version#c-language-version-reference
     -->
-    <LangVersion>11.0</LangVersion>
+    <LangVersion>latest</LangVersion>
 
     <!-- Enable implicit usings:
       https://docs.microsoft.com/dotnet/core/project-sdk/overview#implicit-using-directives
@@ -46,6 +46,14 @@
   <PropertyGroup>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- Configure test and code coverage output. -->
+    <BaseTestResultsOutputPath>$(ArtifactsPath)/test-results/</BaseTestResultsOutputPath>
+    <BaseProjectTestResultsOutputPath>$(BaseTestResultsOutputPath)$(MSBuildProjectName)/</BaseProjectTestResultsOutputPath>
+    <VSTestResultsDirectory>$(BaseProjectTestResultsOutputPath)</VSTestResultsDirectory>
+    <CoverletOutput>$(BaseProjectTestResultsOutputPath)</CoverletOutput>
   </PropertyGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,10 +1,7 @@
 {
   "sdk": {
-    "version": "7.0.100",
+    "version": "8.0.100",
     "allowPrerelease": false,
     "rollForward": "latestFeature"
-  },
-  "msbuild-sdks": {
-    "Treasure.Build.CentralBuildOutput" : "3.0.0"
   }
 }

--- a/src/StartMenuCleaner/Cleaner.cs
+++ b/src/StartMenuCleaner/Cleaner.cs
@@ -84,8 +84,8 @@ internal class Cleaner
     /// Gets the directory items to clean.
     /// </summary>
     /// <param name="directoryPaths">The directory paths.</param>
-    /// <returns><see cref="IReadOnlyList{ItemToClean}"/>.</returns>
-    private IReadOnlyList<ItemToClean> GetDirectoryItemsToClean(IEnumerable<string> directoryPaths)
+    /// <returns>An array of <see cref="ItemToClean"/>.</returns>
+    private ItemToClean[] GetDirectoryItemsToClean(IEnumerable<string> directoryPaths)
         => directoryPaths
         .Where(this.fileSystem.Directory.Exists)
         .SelectMany(this.GetDirectoryItemsToClean)
@@ -103,7 +103,7 @@ internal class Cleaner
             throw new DirectoryNotFoundException(directoryPath);
         }
 
-        List<ItemToClean> items = new();
+        List<ItemToClean> items = [];
 
         foreach (string subdirectoryPath in this.fileSystem.Directory.GetDirectories(directoryPath))
         {
@@ -131,8 +131,8 @@ internal class Cleaner
     /// Gets the file items to clean.
     /// </summary>
     /// <param name="directoryPaths">The directory paths.</param>
-    /// <returns><see cref="IReadOnlyList{ItemToClean}"/>.</returns>
-    private IReadOnlyList<ItemToClean> GetFileItemsToClean(IEnumerable<string> directoryPaths)
+    /// <returns>An array of <see cref="ItemToClean"/>.</returns>
+    private ItemToClean[] GetFileItemsToClean(IEnumerable<string> directoryPaths)
         => directoryPaths
         .Where(this.fileSystem.Directory.Exists)
         .SelectMany(this.GetFileItemsToClean)
@@ -150,7 +150,7 @@ internal class Cleaner
             throw new DirectoryNotFoundException(directoryPath);
         }
 
-        List<ItemToClean> items = new();
+        List<ItemToClean> items = [];
 
         foreach (string filePath in this.fileSystem.Directory.GetFiles(directoryPath))
         {
@@ -167,6 +167,6 @@ internal class Cleaner
         return items;
     }
 
-    private IReadOnlyList<ItemToClean> GetItemsToClean(IEnumerable<string> directoryPaths)
-                            => this.GetFileItemsToClean(directoryPaths).Concat(this.GetDirectoryItemsToClean(directoryPaths)).ToArray();
+    private ItemToClean[] GetItemsToClean(IEnumerable<string> directoryPaths)
+        => this.GetFileItemsToClean(directoryPaths).Concat(this.GetDirectoryItemsToClean(directoryPaths)).ToArray();
 }

--- a/src/StartMenuCleaner/CleanerOptions.cs
+++ b/src/StartMenuCleaner/CleanerOptions.cs
@@ -24,7 +24,7 @@ internal class CleanerOptions
     /// <summary>
     /// Initializes a new instance of the <see cref="CleanerOptions" /> class.
     /// </summary>
-    /// <param name="rootFoldersToClean">The contents of these foldres will be searched and cleaned.</param>
+    /// <param name="rootFoldersToClean">The contents of these folders will be searched and cleaned.</param>
     public CleanerOptions(IReadOnlyList<string> rootFoldersToClean)
         : this(rootFoldersToClean, Constants.DirectoriesToIgnore)
     {
@@ -33,7 +33,7 @@ internal class CleanerOptions
     /// <summary>
     /// Initializes a new instance of the <see cref="CleanerOptions" /> class.
     /// </summary>
-    /// <param name="rootFoldersToClean">The contents of these foldres will be searched and cleaned.</param>
+    /// <param name="rootFoldersToClean">The contents of these folders will be searched and cleaned.</param>
     /// <param name="foldersToIgnore">The folders to ignore.</param>
     public CleanerOptions(IReadOnlyList<string> rootFoldersToClean, IReadOnlyList<string> foldersToIgnore)
     {
@@ -61,6 +61,6 @@ internal class CleanerOptions
         };
     }
 
-    private static IReadOnlyList<string> LoadFoldersToIgnoreFromConfiguration(Config config)
+    private static string[] LoadFoldersToIgnoreFromConfiguration(Config config)
         => config.GetAll(Constants.ConfigurationSectionName, "ignore").Select(x => x.GetString()).ToArray();
 }

--- a/src/StartMenuCleaner/Cleaners/File/BadShortcutFileCleaner.cs
+++ b/src/StartMenuCleaner/Cleaners/File/BadShortcutFileCleaner.cs
@@ -10,7 +10,7 @@ internal class BadShortcutFileCleaner : IFileCleaner
 
     private readonly FileSystemOperationHandler fileSystemOperationHandler;
 
-    private readonly IFileShortcutHandler shortcutHandler;
+    private readonly FileShortcutHandler shortcutHandler;
 
     /// <summary>
     /// Gets the cleaner type.
@@ -25,7 +25,7 @@ internal class BadShortcutFileCleaner : IFileCleaner
     /// <param name="fileSystemOperationHandler">The file system operation handler.</param>
     public BadShortcutFileCleaner(
         IFileSystem fileSystem,
-        IFileShortcutHandler shortcutHandler,
+        FileShortcutHandler shortcutHandler,
         FileSystemOperationHandler fileSystemOperationHandler)
     {
         this.fileSystem = fileSystem;

--- a/src/StartMenuCleaner/Constants.cs
+++ b/src/StartMenuCleaner/Constants.cs
@@ -4,19 +4,19 @@ internal static class Constants
 {
     public const string ConfigurationSectionName = "startmenucleaner";
 
-    public static readonly string[] DirectoriesToIgnore = new string[]
-    {
-            "chrome apps",
-            "startup",
-            "maintenance",
-            "accessories",
-            "windows accessories",
-            "windows administrative tools",
-            "windows ease of access",
-            "windows powershell",
-            "windows system",
-            "accessibility",
-            "administrative tools",
-            "system tools"
-    };
+    public static readonly string[] DirectoriesToIgnore =
+    [
+        "chrome apps",
+        "startup",
+        "maintenance",
+        "accessories",
+        "windows accessories",
+        "windows administrative tools",
+        "windows ease of access",
+        "windows powershell",
+        "windows system",
+        "accessibility",
+        "administrative tools",
+        "system tools"
+    ];
 }

--- a/src/StartMenuCleaner/Extensions/ServiceCollectionExtensions.cs
+++ b/src/StartMenuCleaner/Extensions/ServiceCollectionExtensions.cs
@@ -15,8 +15,8 @@ internal static class ServiceCollectionExtensions
     /// <param name="services">The services.</param>
     /// <returns><see cref="IServiceCollection"/>.</returns>
     public static IServiceCollection RegisterFileShortcutHandler<TShortcutHandler>(this IServiceCollection services)
-        where TShortcutHandler : class, IFileShortcutHandler
-        => services.AddSingleton<IFileShortcutHandler, TShortcutHandler>();
+        where TShortcutHandler : FileShortcutHandler
+        => services.AddSingleton<FileShortcutHandler, TShortcutHandler>();
 
     /// <summary>
     /// Adds the file system to the service collection.

--- a/src/StartMenuCleaner/FileClassifier.cs
+++ b/src/StartMenuCleaner/FileClassifier.cs
@@ -23,28 +23,28 @@ internal class FileClassifier
 
     private const string urlFileExtension = ".url";
 
-    private static readonly string[] appExtensions = new string[]
-    {
-            exeFileExtension,
-            apprefmsFileExtension
-    };
+    private static readonly string[] appExtensions =
+    [
+        exeFileExtension,
+        apprefmsFileExtension
+    ];
 
-    private static readonly string[] deletableExtensions = new string[]
-    {
-            txtFileExtension
-    };
+    private static readonly string[] deletableExtensions =
+    [
+        txtFileExtension
+    ];
 
-    private static readonly ISet<string> uninstallerExtensions = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase)
-        {
-            exeFileExtension,
-            msiFileExtension
-        };
+    private static readonly HashSet<string> uninstallerExtensions = new(StringComparer.InvariantCultureIgnoreCase)
+    {
+        exeFileExtension,
+        msiFileExtension
+    };
 
     private readonly IFileSystem fileSystem;
 
-    private readonly IFileShortcutHandler shortcutHandler;
+    private readonly FileShortcutHandler shortcutHandler;
 
-    public FileClassifier(IFileSystem fileSystem, IFileShortcutHandler shortcutHandler)
+    public FileClassifier(IFileSystem fileSystem, FileShortcutHandler shortcutHandler)
     {
         this.fileSystem = fileSystem;
         this.shortcutHandler = shortcutHandler;

--- a/src/StartMenuCleaner/Program.cs
+++ b/src/StartMenuCleaner/Program.cs
@@ -49,7 +49,7 @@ internal class Program
         }
     }
 
-    private static IServiceProvider ConfigureServices(ProgramOptions options, IFileSystem fileSystem)
+    private static ServiceProvider ConfigureServices(ProgramOptions options, IFileSystem fileSystem)
     {
         CleanerOptions cleanerOptions = CleanerOptions.Load(options.Simulate);
 

--- a/src/StartMenuCleaner/StartMenuCleaner.csproj
+++ b/src/StartMenuCleaner/StartMenuCleaner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackAsTool>True</PackAsTool>
     <ToolCommandName>Clean-StartMenu</ToolCommandName>

--- a/src/StartMenuCleaner/Utils/CsWin32ShortcutHandler.cs
+++ b/src/StartMenuCleaner/Utils/CsWin32ShortcutHandler.cs
@@ -7,9 +7,9 @@ using Windows.Win32.Storage.FileSystem;
 using Windows.Win32.System.Com;
 using Windows.Win32.UI.Shell;
 
-internal class CsWin32ShortcutHandler : IFileShortcutHandler
+internal class CsWin32ShortcutHandler : FileShortcutHandler
 {
-    public unsafe string ResolveTarget(string shortcutPath)
+    public override unsafe string ResolveTarget(string shortcutPath)
     {
         if (!OperatingSystem.IsWindowsVersionAtLeast(5, 1, 2600))
         {

--- a/src/StartMenuCleaner/Utils/FileShortcut.cs
+++ b/src/StartMenuCleaner/Utils/FileShortcut.cs
@@ -56,10 +56,7 @@ public class FileShortcut : IEquatable<FileShortcut>
     /// <exception cref="ArgumentNullException"></exception>
     public static FileShortcut FromString(string shortcutPathSyntax)
     {
-        if (shortcutPathSyntax is null)
-        {
-            throw new ArgumentNullException(nameof(shortcutPathSyntax));
-        }
+        ArgumentNullException.ThrowIfNull(shortcutPathSyntax);
 
         string[] fragments = shortcutPathSyntax.Split(fragmentSeparator, StringSplitOptions.TrimEntries);
 

--- a/src/StartMenuCleaner/Utils/FileShortcutHandler.cs
+++ b/src/StartMenuCleaner/Utils/FileShortcutHandler.cs
@@ -1,11 +1,17 @@
 ﻿namespace StartMenuCleaner.Utils;
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
-internal interface IFileShortcutHandler
+internal abstract class FileShortcutHandler
 {
     private const string lnkFileExtension = ".lnk";
+
+    /// <summary>
+    /// Resolves the target path of the specified shortcut.
+    /// </summary>
+    /// <param name="shortcutPath">The shortcut path.</param>
+    /// <returns><see cref="string"/>.</returns>
+    public abstract string ResolveTarget(string shortcutPath);
 
     /// <summary>
     /// Get a file shortcut.
@@ -28,19 +34,12 @@ internal interface IFileShortcutHandler
     /// </summary>
     /// <param name="filePath">The file path.</param>
     /// <returns><see cref="bool"/>.</returns>
-    public bool IsShortcut(string filePath)
+    public static bool IsShortcut(string filePath)
     {
         string ext = Path.GetExtension(filePath);
 
         return ext == lnkFileExtension;
     }
-
-    /// <summary>
-    /// Resolves the target path of the specified shortcut.
-    /// </summary>
-    /// <param name="shortcutPath">The shortcut path.</param>
-    /// <returns><see cref="string"/>.</returns>
-    string ResolveTarget(string shortcutPath);
 
     /// <summary>
     /// Tries to get a file shortcut.
@@ -53,7 +52,7 @@ internal interface IFileShortcutHandler
     {
         shortcut = null;
 
-        if (!this.IsShortcut(filePath))
+        if (!IsShortcut(filePath))
         {
             return false;
         }

--- a/test/.editorconfig
+++ b/test/.editorconfig
@@ -9,3 +9,6 @@ dotnet_diagnostic.CS1591.severity = none
 
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.CA1707.severity = none
+
+# CA1861: Avoid constant arrays as arguments
+dotnet_diagnostic.CA1861.severity = none

--- a/test/StartMenuCleaner.TestLibrary/EmbeddedResourceHelper.cs
+++ b/test/StartMenuCleaner.TestLibrary/EmbeddedResourceHelper.cs
@@ -34,15 +34,8 @@ public class EmbeddedResourceHelper
     /// </exception>
     public EmbeddedResourceHelper(Assembly resourceAssembly, IFileSystem fileSystem)
     {
-        if (resourceAssembly is null)
-        {
-            throw new ArgumentNullException(nameof(resourceAssembly));
-        }
-
-        if (fileSystem is null)
-        {
-            throw new ArgumentNullException(nameof(fileSystem));
-        }
+        ArgumentNullException.ThrowIfNull(resourceAssembly);
+        ArgumentNullException.ThrowIfNull(fileSystem);
 
         this.resourceAssembly = resourceAssembly;
         this.fileSystem = fileSystem;

--- a/test/StartMenuCleaner.TestLibrary/MockFileSystemComposer.cs
+++ b/test/StartMenuCleaner.TestLibrary/MockFileSystemComposer.cs
@@ -8,7 +8,7 @@ using StartMenuCleaner.Utils;
 /// <summary>
 /// Class MockFileSystemComposer.
 /// </summary>
-public class MockFileSystemComposer
+internal class MockFileSystemComposer
 {
     private readonly IReadOnlyList<string> defaultFileSystemNodes;
 

--- a/test/StartMenuCleaner.TestLibrary/MockManualConfigurationLoader.cs
+++ b/test/StartMenuCleaner.TestLibrary/MockManualConfigurationLoader.cs
@@ -25,14 +25,14 @@ public class MockManualConfigurationLoader : IManualConfigurationLoader
                 f => f,
                 f => new ManualFileRemoveConfiguration(f),
                 StringComparer.OrdinalIgnoreCase)
-            ?? new();
+            ?? [];
 
         this.directoryConfigurations = directories?
             .ToDictionary(
                 d => d.Key,
                 d => new ManualDirectoryRemoveConfiguration(d.Key, d.Value ?? Array.Empty<string>()),
                 StringComparer.OrdinalIgnoreCase)
-            ?? new();
+            ?? [];
     }
 
     /// <summary>

--- a/test/StartMenuCleaner.TestLibrary/StartMenuCleaner.TestLibrary.csproj
+++ b/test/StartMenuCleaner.TestLibrary/StartMenuCleaner.TestLibrary.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>

--- a/test/StartMenuCleaner.TestLibrary/StartMenuCleaner.TestLibrary.csproj
+++ b/test/StartMenuCleaner.TestLibrary/StartMenuCleaner.TestLibrary.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -9,6 +9,10 @@
   <ItemGroup>
     <PackageReference Include="System.IO.Abstractions" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="StartMenuCleaner.Tests" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/StartMenuCleaner.TestLibrary/TestFileShortcutHandler.cs
+++ b/test/StartMenuCleaner.TestLibrary/TestFileShortcutHandler.cs
@@ -7,10 +7,10 @@ using StartMenuCleaner.Utils;
 
 /// <summary>
 /// Class TestFileShortcutHandler.
-/// Implements the <see cref="IFileShortcutHandler" />
+/// Implements the <see cref="FileShortcutHandler" />
 /// </summary>
-/// <seealso cref="IFileShortcutHandler" />
-public class TestFileShortcutHandler : IFileShortcutHandler
+/// <seealso cref="FileShortcutHandler" />
+internal class TestFileShortcutHandler : FileShortcutHandler
 {
     private readonly IDictionary<string, string> shortcutMap;
 
@@ -52,7 +52,7 @@ public class TestFileShortcutHandler : IFileShortcutHandler
     /// <param name="shortcutPath">The shortcut path.</param>
     /// <returns><see cref="string" />.</returns>
     /// <exception cref="InvalidOperationException"></exception>
-    public string ResolveTarget(string shortcutPath)
+    public override string ResolveTarget(string shortcutPath)
     {
         if (this.shortcutMap.TryGetValue(shortcutPath, out string? shortcutTarget))
         {

--- a/test/StartMenuCleaner.Tests/CleanerOptionsTests.cs
+++ b/test/StartMenuCleaner.Tests/CleanerOptionsTests.cs
@@ -9,8 +9,8 @@ public class CleanerOptionsTests
     public void Constructor()
     {
         // Arrange
-        IReadOnlyList<string> rootFoldersToClean = new[] { "foo" };
-        IReadOnlyList<string> foldersToIgnore = new[] { "foo" }.Concat(Constants.DirectoriesToIgnore).ToArray();
+        IReadOnlyList<string> rootFoldersToClean = ["foo"];
+        IReadOnlyList<string> foldersToIgnore = ["foo", .. Constants.DirectoriesToIgnore];
 
         // Act and assert
         CleanerOptions options = new(rootFoldersToClean);
@@ -31,7 +31,7 @@ public class CleanerOptionsTests
         // Arrange
         bool simulate = true;
         IReadOnlyList<string> expectedRootFoldersToClean = StartMenuHelper.GetKnownStartMenuProgramsFolders();
-        string[] expectedFoldersToIgnore = Constants.DirectoriesToIgnore.Concat(new[] { "App", "App 2" }).ToArray();
+        string[] expectedFoldersToIgnore = [.. Constants.DirectoriesToIgnore, "App", "App 2"];
         EmbeddedResourceHelper embeddedResourceHelper = new(typeof(AssemblyToken).Assembly);
         using TemporaryFile tempFile = embeddedResourceHelper.ToTemporaryFile(@"EmbeddedContent\options.netconfig");
 

--- a/test/StartMenuCleaner.Tests/CleanerTests.cs
+++ b/test/StartMenuCleaner.Tests/CleanerTests.cs
@@ -32,10 +32,7 @@ public class CleanerTests
         cleaner.Start();
 
         // Assert
-        this.AssertFileSystemContains(new[]
-        {
-            @"C:\StartMenu"
-        });
+        this.AssertFileSystemContains([@"C:\StartMenu"]);
     }
 
     [Fact]
@@ -47,10 +44,7 @@ public class CleanerTests
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
-            @"C:\StartMenu"
-        });
+        this.AssertFileSystemContains([@"C:\StartMenu"]);
     }
 
     [Fact]
@@ -58,21 +52,21 @@ public class CleanerTests
     {
         Cleaner cleaner = this.GetCleaner();
 
-        this.fileSystemComposer.Add(new[]
-        {
+        this.fileSystemComposer.Add(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             @"C:\StartMenu\MyApp\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             @"C:\StartMenu\MyApp\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
             @"C:\StartMenu\MyApp\MyApp Help.txt",
-        });
+        ]);
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\MyApp.lnk",
             @"C:\StartMenu\MyApp2.lnk",
-        });
+        ]);
     }
 
     [Fact]
@@ -80,25 +74,25 @@ public class CleanerTests
     {
         Cleaner cleaner = this.GetCleaner();
 
-        this.fileSystemComposer.Add(new[]
-        {
+        this.fileSystemComposer.Add(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             @"C:\StartMenu\MyApp\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             @"C:\StartMenu\MyApp\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
             @"C:\StartMenu\MyApp\MyApp Help.txt",
             @"C:\StartMenu\MyApp\Foo",
-        });
+        ]);
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk",
             @"C:\StartMenu\MyApp\MyApp2.lnk",
             @"C:\StartMenu\MyApp\MyApp Help.lnk",
             @"C:\StartMenu\MyApp\MyApp Help.txt",
             @"C:\StartMenu\MyApp\Foo",
-        });
+        ]);
     }
 
     [Fact]
@@ -106,25 +100,25 @@ public class CleanerTests
     {
         Cleaner cleaner = this.GetCleaner();
 
-        this.fileSystemComposer.Add(new[]
-        {
+        this.fileSystemComposer.Add(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             @"C:\StartMenu\MyApp\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             @"C:\StartMenu\MyApp\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
             @"C:\StartMenu\MyApp\MyApp Help.txt",
             @"C:\StartMenu\MyApp\Foo.other",
-        });
+        ]);
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk",
             @"C:\StartMenu\MyApp\MyApp2.lnk",
             @"C:\StartMenu\MyApp\MyApp Help.lnk",
             @"C:\StartMenu\MyApp\MyApp Help.txt",
             @"C:\StartMenu\MyApp\Foo.other",
-        });
+        ]);
     }
 
     [Fact]
@@ -154,10 +148,10 @@ public class CleanerTests
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\Maintenance\MyApp.lnk"
-        });
+        ]);
     }
 
     [Fact]
@@ -171,10 +165,10 @@ public class CleanerTests
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\MyApp.lnk"
-        });
+        ]);
     }
 
     [Fact]
@@ -182,19 +176,19 @@ public class CleanerTests
     {
         Cleaner cleaner = this.GetCleaner();
 
-        this.fileSystemComposer.Add(new[]
-        {
+        this.fileSystemComposer.Add(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             @"C:\StartMenu\MyApp\Foo",
-        });
+        ]);
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk",
             @"C:\StartMenu\MyApp\Foo"
-        });
+        ]);
     }
 
     [Fact]
@@ -202,21 +196,21 @@ public class CleanerTests
     {
         Cleaner cleaner = this.GetCleaner();
 
-        this.fileSystemComposer.Add(new[]
-        {
+        this.fileSystemComposer.Add(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             @"C:\StartMenu\MyApp\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             @"C:\StartMenu\MyApp\MyApp3.lnk;C:\Programs\MyApp\MyApp3.exe",
-        });
+        ]);
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk",
             @"C:\StartMenu\MyApp\MyApp2.lnk",
             @"C:\StartMenu\MyApp\MyApp3.lnk",
-        });
+        ]);
     }
 
     [Fact]
@@ -224,19 +218,19 @@ public class CleanerTests
     {
         Cleaner cleaner = this.GetCleaner();
 
-        this.fileSystemComposer.Add(new[]
-        {
+        this.fileSystemComposer.Add(
+        [
             @"C:\StartMenu\MyApp\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             @"C:\StartMenu\MyApp\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
-        });
+        ]);
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
+        this.AssertFileSystemContains(
+        [
             @"C:\StartMenu\MyApp.lnk",
             @"C:\StartMenu\MyApp2.lnk",
-        });
+        ]);
     }
 
     [Fact]
@@ -248,10 +242,7 @@ public class CleanerTests
 
         cleaner.Start();
 
-        this.AssertFileSystemContains(new[]
-        {
-            @"C:\StartMenu\MyApp"
-        });
+        this.AssertFileSystemContains([@"C:\StartMenu\MyApp"]);
     }
 
     private void AssertFileSystemContains(IEnumerable<string> expectedNodes)
@@ -266,7 +257,7 @@ public class CleanerTests
         MockFileSystem mockFileSystem = this.fileSystemComposer.FileSystem;
         TestFileShortcutHandler shortcutHandler = this.fileSystemComposer.ShortcutHandler;
         FileClassifier classifier = new(mockFileSystem, shortcutHandler);
-        CleanerOptions cleanerOptions = new(new[] { @"C:\StartMenu" })
+        CleanerOptions cleanerOptions = new([@"C:\StartMenu"])
         {
             Simulate = simulate
         };
@@ -278,12 +269,12 @@ public class CleanerTests
         {
             new BadShortcutFileCleaner(mockFileSystem, shortcutHandler, fileSystemOperationHandler),
         };
-        IDirectoryCleaner[] directoryCleaners = new IDirectoryCleaner[]
-        {
+        IDirectoryCleaner[] directoryCleaners =
+        [
             new EmptyDirectoryCleaner(mockFileSystem, fileSystemOperationHandler),
             new SingleAppDirectoryCleaner(mockFileSystem, fileSystemOperationHandler, classifier),
             new FewAppsWithCruftDirectoryCleaner(mockFileSystem, fileSystemOperationHandler, classifier),
-        };
+        ];
 
         return new Cleaner(
             cleanerOptions,

--- a/test/StartMenuCleaner.Tests/Cleaners/Directory/DirectoryCleanerTestBase.cs
+++ b/test/StartMenuCleaner.Tests/Cleaners/Directory/DirectoryCleanerTestBase.cs
@@ -9,7 +9,7 @@ public abstract class DirectoryCleanerTestBase
 {
     protected MockFileSystem FileSystem => this.FileSystemComposer.FileSystem;
 
-    protected MockFileSystemComposer FileSystemComposer { get; } = new MockFileSystemComposer();
+    private protected MockFileSystemComposer FileSystemComposer { get; } = new MockFileSystemComposer();
 
     [Fact]
     public void CanClean_DirectoryNotFound()

--- a/test/StartMenuCleaner.Tests/Cleaners/Directory/FewAppsWithCruftDirectoryCleanerTests.cs
+++ b/test/StartMenuCleaner.Tests/Cleaners/Directory/FewAppsWithCruftDirectoryCleanerTests.cs
@@ -16,10 +16,10 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -34,14 +34,14 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             $@"{directoryPath}\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
             $@"{directoryPath}\MyApp Help.txt",
             $@"{directoryPath}\Foo.other",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -56,10 +56,10 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -74,10 +74,10 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp Help.txt",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -92,12 +92,12 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             $@"{directoryPath}\MyApp3.lnk;C:\Programs\MyApp\MyApp3.exe",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -112,11 +112,11 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -131,13 +131,13 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             $@"{directoryPath}\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
             $@"{directoryPath}\MyApp Help.txt",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -153,10 +153,10 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
         string filePath = $@"{directoryPath}\MyApp Help.lnk";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{filePath};C:\Programs\MyApp\MyApp Help.chm",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -171,14 +171,14 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             $@"{directoryPath}\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
             $@"{directoryPath}\MyApp Help.txt",
             $@"{directoryPath}\Foo.other",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act and assert
@@ -196,10 +196,10 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
         string filePath = $@"{directoryPath}\MyApp.lnk";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{filePath};C:\Programs\MyApp\MyApp.exe",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -215,10 +215,10 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
         string filePath = $@"{directoryPath}\MyApp Help.txt";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             filePath,
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -233,12 +233,12 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             $@"{directoryPath}\MyApp3.lnk;C:\Programs\MyApp\MyApp3.exe",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act and assert
@@ -253,11 +253,11 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -273,13 +273,13 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
     {
         // Arrange
         const string directoryPath = @"C:\StartMenu\MyApp";
-        this.FileSystemComposer.Add(new[]
-        {
+        this.FileSystemComposer.Add(
+        [
             $@"{directoryPath}\MyApp.lnk;C:\Programs\MyApp\MyApp.exe",
             $@"{directoryPath}\MyApp2.lnk;C:\Programs\MyApp\MyApp2.exe",
             $@"{directoryPath}\MyApp Help.lnk;C:\Programs\MyApp\MyApp Help.chm",
             $@"{directoryPath}\MyApp Help.txt",
-        });
+        ]);
         IDirectoryCleaner cleaner = this.BuildCleaner();
 
         // Act
@@ -294,7 +294,7 @@ public class FewAppsWithCruftDirectoryCleanerTests : DirectoryCleanerTestBase
 
     private protected override IDirectoryCleaner BuildCleaner()
     {
-        CleanerOptions cleanerOptions = new(new[] { @"C:\StartMenu" })
+        CleanerOptions cleanerOptions = new([@"C:\StartMenu"])
         {
             Simulate = false
         };

--- a/test/StartMenuCleaner.Tests/Cleaners/Directory/ManualConfigurationDirectoryCleanerTests.cs
+++ b/test/StartMenuCleaner.Tests/Cleaners/Directory/ManualConfigurationDirectoryCleanerTests.cs
@@ -22,7 +22,7 @@ public class ManualConfigurationDirectoryCleanerTests : DirectoryCleanerTestBase
         string shortcutDirectoryPath = Path.GetDirectoryName(shortcutFilePath)!;
         const string appFilePath = @"C:\Programs\App.exe";
         this.FileSystemComposer.Add($"{shortcutFilePath};{appFilePath}");
-        IDirectoryCleaner directoryCleaner = this.BuildCleaner(new[] { "App" });
+        ManualConfigurationDirectoryCleaner directoryCleaner = this.BuildCleaner(["App"]);
 
         // Act
         bool result = directoryCleaner.CanClean(shortcutDirectoryPath);
@@ -56,7 +56,7 @@ public class ManualConfigurationDirectoryCleanerTests : DirectoryCleanerTestBase
         string shortcutDirectoryPath = Path.GetDirectoryName(shortcutFilePath)!;
         const string appFilePath = @"C:\Programs\App.exe";
         this.FileSystemComposer.Add($"{shortcutFilePath};{appFilePath}");
-        IDirectoryCleaner directoryCleaner = this.BuildCleaner(new[] { "App" });
+        ManualConfigurationDirectoryCleaner directoryCleaner = this.BuildCleaner(["App"]);
 
         // Act
         directoryCleaner.Clean(shortcutDirectoryPath);
@@ -74,7 +74,7 @@ public class ManualConfigurationDirectoryCleanerTests : DirectoryCleanerTestBase
         const string appFilePath = @"C:\Programs\App.exe";
         this.FileSystemComposer.Add($"{shortcutFilePath};{appFilePath}");
         this.FileSystemComposer.Add(@"C:\StartMenu\App\File.txt");
-        IDirectoryCleaner directoryCleaner = this.BuildCleaner(new Dictionary<string, IEnumerable<string>?>
+        ManualConfigurationDirectoryCleaner directoryCleaner = this.BuildCleaner(new Dictionary<string, IEnumerable<string>?>
         {
             ["App"] = new[] { Path.GetFileName(shortcutFilePath) }
         });
@@ -115,9 +115,9 @@ public class ManualConfigurationDirectoryCleanerTests : DirectoryCleanerTestBase
     private protected override IDirectoryCleaner BuildCleaner()
         => this.BuildCleaner((IDictionary<string, IEnumerable<string>?>?)null);
 
-    private IDirectoryCleaner BuildCleaner(IDictionary<string, IEnumerable<string>?>? directories)
+    private ManualConfigurationDirectoryCleaner BuildCleaner(IDictionary<string, IEnumerable<string>?>? directories)
     {
-        CleanerOptions cleanerOptions = new(new[] { @"C:\StartMenu" })
+        CleanerOptions cleanerOptions = new([@"C:\StartMenu"])
         {
             Simulate = false
         };
@@ -132,6 +132,6 @@ public class ManualConfigurationDirectoryCleanerTests : DirectoryCleanerTestBase
         return cleaner;
     }
 
-    private IDirectoryCleaner BuildCleaner(IEnumerable<string> directories)
-        => this.BuildCleaner(directories.ToDictionary(d => d, _ => (IEnumerable<string>?)Array.Empty<string>(), StringComparer.OrdinalIgnoreCase));
+    private ManualConfigurationDirectoryCleaner BuildCleaner(IEnumerable<string> directories)
+        => this.BuildCleaner(directories.ToDictionary(d => d, _ => (IEnumerable<string>?)[], StringComparer.OrdinalIgnoreCase));
 }

--- a/test/StartMenuCleaner.Tests/Cleaners/File/BadShortcutFileCleanerTests.cs
+++ b/test/StartMenuCleaner.Tests/Cleaners/File/BadShortcutFileCleanerTests.cs
@@ -102,7 +102,7 @@ public class BadShortcutFileCleanerTests : FileCleanerTestBase
 
     private protected override IFileCleaner BuildCleaner()
     {
-        CleanerOptions cleanerOptions = new(new[] { @"C:\StartMenu" })
+        CleanerOptions cleanerOptions = new([@"C:\StartMenu"])
         {
             Simulate = false
         };

--- a/test/StartMenuCleaner.Tests/Cleaners/File/FileCleanerTestBase.cs
+++ b/test/StartMenuCleaner.Tests/Cleaners/File/FileCleanerTestBase.cs
@@ -9,7 +9,7 @@ public abstract class FileCleanerTestBase
 {
     protected MockFileSystem FileSystem => this.FileSystemComposer.FileSystem;
 
-    protected MockFileSystemComposer FileSystemComposer { get; } = new MockFileSystemComposer();
+    private protected MockFileSystemComposer FileSystemComposer { get; } = new MockFileSystemComposer();
 
     [Fact]
     public void CanClean_FileNotExist()

--- a/test/StartMenuCleaner.Tests/Cleaners/File/ManualConfigurationFileCleanerTests.cs
+++ b/test/StartMenuCleaner.Tests/Cleaners/File/ManualConfigurationFileCleanerTests.cs
@@ -21,7 +21,7 @@ public class ManualConfigurationFileCleanerTests : FileCleanerTestBase
         // Arrange
         const string shortcutFilePath = @"C:\StartMenu\Shortcut.lnk";
         const string appFilePath = @"C:\Programs\App.exe";
-        IFileCleaner fileCleaner = this.BuildCleaner(new[] { "Shortcut.lnk" });
+        ManualConfigurationFileCleaner fileCleaner = this.BuildCleaner(new[] { "Shortcut.lnk" });
         this.FileSystemComposer.Add($"{shortcutFilePath};{appFilePath}");
 
         // Act
@@ -53,7 +53,7 @@ public class ManualConfigurationFileCleanerTests : FileCleanerTestBase
         // Arrange
         const string shortcutFilePath = @"C:\StartMenu\Shortcut.lnk";
         const string appFilePath = @"C:\Programs\App.exe";
-        IFileCleaner fileCleaner = this.BuildCleaner(new[] { "Shortcut.lnk" });
+        ManualConfigurationFileCleaner fileCleaner = this.BuildCleaner(new[] { "Shortcut.lnk" });
         this.FileSystemComposer.Add($"{shortcutFilePath};{appFilePath}");
 
         // Act
@@ -88,7 +88,7 @@ public class ManualConfigurationFileCleanerTests : FileCleanerTestBase
 
     private protected override IFileCleaner BuildCleaner() => this.BuildCleaner(null);
 
-    private IFileCleaner BuildCleaner(IEnumerable<string>? files)
+    private ManualConfigurationFileCleaner BuildCleaner(IEnumerable<string>? files)
     {
         CleanerOptions cleanerOptions = new(new[] { @"C:\StartMenu" })
         {

--- a/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
+++ b/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/StartMenuCleaner.Tests/Utils/FileShortcutHandlerTests.cs
+++ b/test/StartMenuCleaner.Tests/Utils/FileShortcutHandlerTests.cs
@@ -9,19 +9,17 @@ using StartMenuCleaner.Utils;
 
 using Xunit;
 
-public class IFileShortcutHandlerTests
+public class FileShortcutHandlerTests
 {
-    private readonly TestFileShortcutHandler testShortcutHandler = new();
-
-    private IFileShortcutHandler ShortcutHandler => this.testShortcutHandler;
+    private readonly TestFileShortcutHandler shortcutHandler = new();
 
     [Fact]
     public void GetShortcut()
     {
         FileShortcut expectedFileShortcut = new(@"C:\StartMenu\MyApp\MyApp.lnk", @"C:\Programs\MyApp\MyApp.exe");
-        this.testShortcutHandler.AddShortcutMapping(expectedFileShortcut);
+        this.shortcutHandler.AddShortcutMapping(expectedFileShortcut);
 
-        FileShortcut shortcut = this.ShortcutHandler.GetShortcut(expectedFileShortcut.FilePath);
+        FileShortcut shortcut = this.shortcutHandler.GetShortcut(expectedFileShortcut.FilePath);
         shortcut.Should().Be(expectedFileShortcut);
     }
 
@@ -29,23 +27,28 @@ public class IFileShortcutHandlerTests
     public void GetShortcutFromInvalidPath()
     {
         Assert.Throws<ArgumentException>("filePath", () =>
-            this.ShortcutHandler.GetShortcut(@"C:\StartMenu\MyApp\MyApp.txt"));
+            this.shortcutHandler.GetShortcut(@"C:\StartMenu\MyApp\MyApp.txt"));
     }
 
     [Fact]
-    public void IsShortcut()
+    public void IsShortcut_ContainsNonShortcutExtension_ReturnsFalse()
     {
-        this.ShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.lnk").Should().Be(true);
-        this.ShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.txt").Should().Be(false);
+        FileShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.txt").Should().Be(false);
+    }
+
+    [Fact]
+    public void IsShortcut_ContainsShortcutExtension_ReturnsTrue()
+    {
+        FileShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.lnk").Should().Be(true);
     }
 
     [Fact]
     public void TryGetShortcut()
     {
         FileShortcut expectedFileShortcut = new(@"C:\StartMenu\MyApp\MyApp.lnk", @"C:\Programs\MyApp\MyApp.exe");
-        this.testShortcutHandler.AddShortcutMapping(expectedFileShortcut);
+        this.shortcutHandler.AddShortcutMapping(expectedFileShortcut);
 
-        this.ShortcutHandler.TryGetShortcut(expectedFileShortcut.FilePath, out FileShortcut? shortcut)
+        this.shortcutHandler.TryGetShortcut(expectedFileShortcut.FilePath, out FileShortcut? shortcut)
             .Should().Be(true);
 
         shortcut.Should().Be(expectedFileShortcut);
@@ -54,7 +57,7 @@ public class IFileShortcutHandlerTests
     [Fact]
     public void TryGetShortcutFromInvalidPath()
     {
-        this.ShortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.txt", out FileShortcut? shortcut)
+        this.shortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.txt", out FileShortcut? shortcut)
             .Should().Be(false);
 
         shortcut.Should().BeNull();
@@ -65,7 +68,7 @@ public class IFileShortcutHandlerTests
     {
         // Don't register the link causing the TestFileShortcutHandler to
         // throw in ResolveTarget.
-        this.ShortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.lnk", out FileShortcut? shortcut)
+        this.shortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.lnk", out FileShortcut? shortcut)
             .Should().Be(false);
 
         shortcut.Should().BeNull();


### PR DESCRIPTION
- Upgrade to .NET 8 SDK and Runtime
- Address .NET 8 analyzer warnings
  - Addresses the analyzer warnings introduced by .NET 8. One of the big changes here is the conversion from the `IFileShortcutHandler` interface to the `FileShortcutHandler` abstract class called out for performance implications. The use of the interface methods was one of my first attempts at using that feature and I've decided that I'm not a huge fan of it in this particular case.