### PR TITLE
Upgrade Serilog.Sinks.Console

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWin32"                         Version="0.3.49-beta" />
     <PackageVersion Include="Serilog"                                           Version="3.1.1" />
     <PackageVersion Include="Serilog.Extensions.Logging"                        Version="8.0.0" />
-    <PackageVersion Include="Serilog.Sinks.Console"                             Version="5.0.0" />
+    <PackageVersion Include="Serilog.Sinks.Console"                             Version="5.0.1" />
     <PackageVersion Include="Serilog.Sinks.File"                                Version="5.0.0" />
     <PackageVersion Include="Serilog.Sinks.Trace"                               Version="3.0.0" />
     <PackageVersion Include="System.IO.Abstractions"                            Version="19.2.87" />


### PR DESCRIPTION
This change upgrades `Serilog.Sinks.Console` to `5.0.1`.