### PR TITLE
Change Divergic.Logging.Xunit to Neovolve.Logging.Xunit version 6.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -40,10 +40,10 @@
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
     <PackageVersion Include="coverlet.collector"                                Version="6.0.2" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.2" />
-    <PackageVersion Include="Divergic.Logging.Xunit"                            Version="4.3.1" />
     <PackageVersion Include="FluentAssertions"                                  Version="6.12.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="8.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.10.0" />
+    <PackageVersion Include="Neovolve.Logging.Xunit"                            Version="6.1.0" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />
     <PackageVersion Include="xunit"                                             Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="2.8.2" />

--- a/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
+++ b/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
@@ -25,9 +25,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Divergic.Logging.Xunit" />
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Neovolve.Logging.Xunit" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">


### PR DESCRIPTION
The `Divergic.Logging.Xunit` package has been deprecated in favor of the new name `Neovolve.Logging.Xunit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the logging framework used in test dependencies by replacing `Divergic.Logging.Xunit` with `Neovolve.Logging.Xunit`. This change may influence logging behavior during test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->