### PR TITLE
Remove Treasure.Utils.Argument

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,6 @@
     <PackageVersion Include="Serilog.Sinks.File"                                Version="6.0.0" />
     <PackageVersion Include="Serilog.Sinks.Trace"                               Version="4.0.0" />
     <PackageVersion Include="System.IO.Abstractions"                            Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="Treasure.Utils.Argument"                           Version="1.1.0" />
   </ItemGroup>
 
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">

--- a/src/StartMenuCleaner/CleanerOptions.cs
+++ b/src/StartMenuCleaner/CleanerOptions.cs
@@ -37,8 +37,11 @@ internal class CleanerOptions
     /// <param name="foldersToIgnore">The folders to ignore.</param>
     public CleanerOptions(IReadOnlyList<string> rootFoldersToClean, IReadOnlyList<string> foldersToIgnore)
     {
-        this.RootFoldersToClean = Argument.NotNull(rootFoldersToClean);
-        this.FoldersToIgnore = new HashSet<string>(Argument.NotNull(foldersToIgnore), StringComparer.CurrentCultureIgnoreCase);
+        ArgumentNullException.ThrowIfNull(rootFoldersToClean);
+        ArgumentNullException.ThrowIfNull(foldersToIgnore);
+
+        this.RootFoldersToClean = rootFoldersToClean;
+        this.FoldersToIgnore = new HashSet<string>(foldersToIgnore, StringComparer.CurrentCultureIgnoreCase);
     }
 
     /// <summary>

--- a/src/StartMenuCleaner/StartMenuCleaner.csproj
+++ b/src/StartMenuCleaner/StartMenuCleaner.csproj
@@ -13,10 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Using Include="Treasure.Utils" />
-  </ItemGroup>
-
-  <ItemGroup>
     <InternalsVisibleTo Include="StartMenuCleaner.Tests" />
     <InternalsVisibleTo Include="StartMenuCleaner.TestLibrary" />
   </ItemGroup>
@@ -34,7 +30,6 @@
     <PackageReference Include="Serilog.Sinks.File" />
     <PackageReference Include="Serilog.Sinks.Trace" />
     <PackageReference Include="System.IO.Abstractions" />
-    <PackageReference Include="Treasure.Utils.Argument" />
   </ItemGroup>
 
 </Project>

--- a/src/StartMenuCleaner/Utils/FileShortcut.cs
+++ b/src/StartMenuCleaner/Utils/FileShortcut.cs
@@ -46,7 +46,12 @@ internal sealed class FileShortcut : IEquatable<FileShortcut>
     /// </summary>
     /// <param name="fileShortcut">The shortcut path.</param>
     /// <returns>The result of the conversion.</returns>
-    public static explicit operator string(FileShortcut fileShortcut) => Argument.NotNull(fileShortcut).ToString();
+    public static explicit operator string(FileShortcut fileShortcut)
+    {
+        ArgumentNullException.ThrowIfNull(fileShortcut);
+
+        return fileShortcut.ToString();
+    }
 
     /// <summary>
     /// Converts shortcut path syntax ("{file_path};{target_path}") to a <see cref="FileShortcut"/>.
@@ -84,7 +89,7 @@ internal sealed class FileShortcut : IEquatable<FileShortcut>
     /// <returns><see cref="bool"/>.</returns>
     public static bool TryConvertFrom(string shortcutPathSyntax, [NotNullWhen(true)] out FileShortcut? fileShortcut)
     {
-        Argument.NotNullOrWhiteSpace(shortcutPathSyntax);
+        ArgumentException.ThrowIfNullOrWhiteSpace(shortcutPathSyntax);
 
         fileShortcut = null;
 

--- a/src/StartMenuCleaner/Utils/ManualDirectoryRemoveConfiguration.cs
+++ b/src/StartMenuCleaner/Utils/ManualDirectoryRemoveConfiguration.cs
@@ -19,8 +19,10 @@ internal sealed class ManualDirectoryRemoveConfiguration
     /// <param name="filesToPromote">The files to keep and promote.</param>
     public ManualDirectoryRemoveConfiguration(string directoryName, IEnumerable<string> filesToPromote)
     {
-        this.DirectoryName = Argument.NotNullOrWhiteSpace(directoryName);
-        Argument.NotNull(filesToPromote);
+        ArgumentException.ThrowIfNullOrWhiteSpace(directoryName);
+        ArgumentNullException.ThrowIfNull(filesToPromote);
+
+        this.DirectoryName = directoryName;
         this.FilesToPromote = new HashSet<string>(filesToPromote, StringComparer.OrdinalIgnoreCase);
     }
 }

--- a/src/StartMenuCleaner/Utils/ManualFileRemoveConfiguration.cs
+++ b/src/StartMenuCleaner/Utils/ManualFileRemoveConfiguration.cs
@@ -13,6 +13,8 @@ internal sealed class ManualFileRemoveConfiguration
     /// <param name="fileName">The name of the file.</param>
     public ManualFileRemoveConfiguration(string fileName)
     {
-        this.FileName = Argument.NotNullOrWhiteSpace(fileName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fileName);
+
+        this.FileName = fileName;
     }
 }


### PR DESCRIPTION
Treasure.Utils.Argument is unnecessary for .NET 8+.