### PR TITLE
Use Windows 2025 for builds

### DIFF
--- a/.github/workflows/workflow_build.yml
+++ b/.github/workflows/workflow_build.yml
@@ -6,9 +6,6 @@ on:
       checkFormat:
         type: boolean
         default: true
-      platform:
-        type: string
-        default: ubuntu
     outputs:
       package_version:
         description: 'The version of the package that was built.'
@@ -21,7 +18,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     outputs:
       package_version: ${{steps.version.outputs.package_version}}


### PR DESCRIPTION
According to [this announcement](https://github.blog/changelog/2024-12-19-windows-server-2025-is-now-in-public-preview/), Windows Server 2025 is now available to use in preview.. Initial build shows it being much faster than previous Windows build agents, so we'll try it out.