### PR TITLE
Update xUnit to v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -42,10 +42,11 @@
     <PackageVersion Include="FluentAssertions"                                  Version="7.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.12.0" />
-    <PackageVersion Include="Neovolve.Logging.Xunit"                            Version="6.2.0" />
+    <PackageVersion Include="Neovolve.Logging.Xunit.v3"                         Version="7.0.0-beta0006" />
     <PackageVersion Include="System.IO.Abstractions.TestingHelpers"             Version="$(SystemIOAbstractionsVersion)" />
-    <PackageVersion Include="xunit"                                             Version="2.9.2" />
+    <PackageVersion Include="xunit.analyzers"                                   Version="1.18.0" />
     <PackageVersion Include="xunit.runner.visualstudio"                         Version="3.0.0" />
+    <PackageVersion Include="xunit.v3"                                          Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
+++ b/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <ItemGroup>
     <Using Include="Xunit" />
-    <Using Include="Xunit.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,13 +27,17 @@
     </PackageReference>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Neovolve.Logging.Xunit" />
+    <PackageReference Include="Neovolve.Logging.Xunit.v3" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change updates xUnit to v3 by following the [migration guide](https://xunit.net/docs/getting-started/v3/migration).

Note: Currently using beta bits for `Neovolve.Logging.Xunit.v3`.