### PR TITLE
Remove FluentAssertions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,6 @@
   <ItemGroup Label="Test Only Packages" Condition=" '$(TestOnlyPackagesEnabled)' == 'true' ">
     <PackageVersion Include="coverlet.collector"                                Version="6.0.3" />
     <PackageVersion Include="coverlet.msbuild"                                  Version="6.0.3" />
-    <PackageVersion Include="FluentAssertions"                                  Version="7.0.0" />
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing"                  Version="9.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk"                            Version="17.12.0" />
     <PackageVersion Include="Neovolve.Logging.Xunit.v3"                         Version="7.1.0" />

--- a/test/StartMenuCleaner.Tests/CleanerTests.cs
+++ b/test/StartMenuCleaner.Tests/CleanerTests.cs
@@ -2,8 +2,6 @@
 
 using System.IO.Abstractions.TestingHelpers;
 
-using FluentAssertions;
-
 using Microsoft.Extensions.Logging;
 
 using StartMenuCleaner.Cleaners.Directory;
@@ -126,7 +124,7 @@ public class CleanerTests
     {
         Cleaner cleaner = this.GetCleaner();
 
-        string[] ignoredDirectoryPaths = Constants.DirectoriesToIgnore.Select(d => $@"C:\StartMenu\{d}").ToArray();
+        string[] ignoredDirectoryPaths = [.. Constants.DirectoriesToIgnore.Select(d => $@"C:\StartMenu\{d}")];
         foreach (string ignoredDirectoryPath in ignoredDirectoryPaths)
         {
             this.fileSystemComposer.AddDirectory(ignoredDirectoryPath);
@@ -248,7 +246,7 @@ public class CleanerTests
     private void AssertFileSystemContains(IEnumerable<string> expectedNodes)
     {
         IEnumerable<string> fileSystemNodes = this.fileSystemComposer.GetAllNodes();
-        expectedNodes.Should().BeEquivalentTo(fileSystemNodes);
+        Assert.Equivalent(expectedNodes, fileSystemNodes);
     }
 
     private Cleaner GetCleaner(bool simulate = false)

--- a/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
+++ b/test/StartMenuCleaner.Tests/StartMenuCleaner.Tests.csproj
@@ -25,7 +25,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Neovolve.Logging.Xunit.v3" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" />

--- a/test/StartMenuCleaner.Tests/Utils/CsWin32ShortcutHandlerTests.cs
+++ b/test/StartMenuCleaner.Tests/Utils/CsWin32ShortcutHandlerTests.cs
@@ -2,8 +2,6 @@
 
 using System.IO;
 
-using FluentAssertions;
-
 using StartMenuCleaner.TestLibrary;
 using StartMenuCleaner.Utils;
 
@@ -23,7 +21,7 @@ public class CsWin32ShortcutHandlerTests
             CsWin32ShortcutHandler shortcutHandler = new();
             string actualTargetPath = shortcutHandler.ResolveTarget(temporaryFilePath);
 
-            actualTargetPath.Should().Be(@"C:\Windows\System32\systeminfo.exe");
+            Assert.Equal(@"C:\Windows\System32\systeminfo.exe", actualTargetPath);
         }
         finally
         {

--- a/test/StartMenuCleaner.Tests/Utils/FileShortcutHandlerTests.cs
+++ b/test/StartMenuCleaner.Tests/Utils/FileShortcutHandlerTests.cs
@@ -2,8 +2,6 @@
 
 using System;
 
-using FluentAssertions;
-
 using StartMenuCleaner.TestLibrary;
 using StartMenuCleaner.Utils;
 
@@ -20,7 +18,7 @@ public class FileShortcutHandlerTests
         this.shortcutHandler.AddShortcutMapping(expectedFileShortcut);
 
         FileShortcut shortcut = this.shortcutHandler.GetShortcut(expectedFileShortcut.FilePath);
-        shortcut.Should().Be(expectedFileShortcut);
+        Assert.Equal(expectedFileShortcut, shortcut);
     }
 
     [Fact]
@@ -33,44 +31,59 @@ public class FileShortcutHandlerTests
     [Fact]
     public void IsShortcut_ContainsNonShortcutExtension_ReturnsFalse()
     {
-        FileShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.txt").Should().Be(false);
+        // Act
+        bool result = FileShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.txt");
+
+        // Assert
+        Assert.False(result);
     }
 
     [Fact]
     public void IsShortcut_ContainsShortcutExtension_ReturnsTrue()
     {
-        FileShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.lnk").Should().Be(true);
+        // Act
+        bool result = FileShortcutHandler.IsShortcut(@"C:\StartMenu\MyApp\MyApp.lnk");
+
+        // Assert
+        Assert.True(result);
     }
 
     [Fact]
     public void TryGetShortcut()
     {
+        // Arrange
         FileShortcut expectedFileShortcut = new(@"C:\StartMenu\MyApp\MyApp.lnk", @"C:\Programs\MyApp\MyApp.exe");
         this.shortcutHandler.AddShortcutMapping(expectedFileShortcut);
 
-        this.shortcutHandler.TryGetShortcut(expectedFileShortcut.FilePath, out FileShortcut? shortcut)
-            .Should().Be(true);
+        // Act
+        bool result = this.shortcutHandler.TryGetShortcut(expectedFileShortcut.FilePath, out FileShortcut? shortcut);
 
-        shortcut.Should().Be(expectedFileShortcut);
+        // Assert
+        Assert.True(result);
+        Assert.Equal(expectedFileShortcut, shortcut);
     }
 
     [Fact]
     public void TryGetShortcutFromInvalidPath()
     {
-        this.shortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.txt", out FileShortcut? shortcut)
-            .Should().Be(false);
+        // Act
+        bool result = this.shortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.txt", out FileShortcut? shortcut);
 
-        shortcut.Should().BeNull();
+        // Assert
+        Assert.False(result);
+        Assert.Null(shortcut);
     }
 
     [Fact]
     public void TryGetShortcutWithResolutionFailure()
     {
+        // Act
         // Don't register the link causing the TestFileShortcutHandler to
         // throw in ResolveTarget.
-        this.shortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.lnk", out FileShortcut? shortcut)
-            .Should().Be(false);
+        bool result = this.shortcutHandler.TryGetShortcut(@"C:\StartMenu\MyApp\MyApp.lnk", out FileShortcut? shortcut);
 
-        shortcut.Should().BeNull();
+        // Assert
+        Assert.False(result);
+        Assert.Null(shortcut);
     }
 }

--- a/test/StartMenuCleaner.Tests/Utils/StartMenuHelperTests.cs
+++ b/test/StartMenuCleaner.Tests/Utils/StartMenuHelperTests.cs
@@ -1,7 +1,5 @@
 ﻿namespace StartMenuCleaner.Tests.Utils;
 
-using FluentAssertions;
-
 using StartMenuCleaner.Utils;
 
 using Xunit;
@@ -10,9 +8,21 @@ public class StartMenuHelperTests
 {
     [Fact]
     public void GetKnownStartMenuFolders()
-        => StartMenuHelper.GetKnownStartMenuFolders().Should().HaveCount(2);
+    {
+        // Act
+        IReadOnlyList<string> result = StartMenuHelper.GetKnownStartMenuFolders();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
 
     [Fact]
     public void GetKnownStartMenuProgramsFolders()
-        => StartMenuHelper.GetKnownStartMenuProgramsFolders().Should().HaveCount(2);
+    {
+        // Act
+        IReadOnlyList<string> result = StartMenuHelper.GetKnownStartMenuProgramsFolders();
+
+        // Assert
+        Assert.Equal(2, result.Count);
+    }
 }


### PR DESCRIPTION
FluentAssertions are completely unnecessary and given the change in direction for FluentAssertions, best to just set it aside altogether.