### PR TITLE
Configure .NET SDK updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,13 @@ updates:
       - "Nerdbank.GitVersioning"
       - "nbgv"
 
+- package-ecosystem: 'dotnet-sdk'
+  directory: "/"
+  schedule:
+    interval: 'weekly'
+    day: 'tuesday'
+    time: '22:00'
+
 - package-ecosystem: github-actions
   directory: "/"
   schedule:

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "9.0.200",
     "allowPrerelease": false,
-    "rollForward": "latestFeature"
+    "rollForward": "latestPatch"
   }
 }

--- a/src/StartMenuCleaner/Cleaner.cs
+++ b/src/StartMenuCleaner/Cleaner.cs
@@ -86,10 +86,9 @@ internal class Cleaner
     /// <param name="directoryPaths">The directory paths.</param>
     /// <returns>An array of <see cref="ItemToClean"/>.</returns>
     private ItemToClean[] GetDirectoryItemsToClean(IEnumerable<string> directoryPaths)
-        => directoryPaths
+        => [.. directoryPaths
         .Where(this.fileSystem.Directory.Exists)
-        .SelectMany(this.GetDirectoryItemsToClean)
-        .ToArray();
+        .SelectMany(this.GetDirectoryItemsToClean)];
 
     /// <summary>
     /// Gets the directory items to clean.
@@ -133,10 +132,9 @@ internal class Cleaner
     /// <param name="directoryPaths">The directory paths.</param>
     /// <returns>An array of <see cref="ItemToClean"/>.</returns>
     private ItemToClean[] GetFileItemsToClean(IEnumerable<string> directoryPaths)
-        => directoryPaths
+        => [.. directoryPaths
         .Where(this.fileSystem.Directory.Exists)
-        .SelectMany(this.GetFileItemsToClean)
-        .ToArray();
+        .SelectMany(this.GetFileItemsToClean)];
 
     /// <summary>
     /// Gets the file items to clean.

--- a/src/StartMenuCleaner/CleanerOptions.cs
+++ b/src/StartMenuCleaner/CleanerOptions.cs
@@ -65,5 +65,5 @@ internal class CleanerOptions
     }
 
     private static string[] LoadFoldersToIgnoreFromConfiguration(Config config)
-        => config.GetAll(Constants.ConfigurationSectionName, "ignore").Select(x => x.GetString()).ToArray();
+        => [.. config.GetAll(Constants.ConfigurationSectionName, "ignore").Select(x => x.GetString())];
 }

--- a/src/StartMenuCleaner/Cleaners/Directory/FewAppsWithCruftDirectoryCleaner.cs
+++ b/src/StartMenuCleaner/Cleaners/Directory/FewAppsWithCruftDirectoryCleaner.cs
@@ -43,13 +43,11 @@ internal class FewAppsWithCruftDirectoryCleaner : DirectoryCleanerBase
             return false;
         }
 
-        IReadOnlyList<string> filePaths = this.FileSystem.Directory.EnumerateFiles(directoryPath)
-            .ToArray();
+        IReadOnlyList<string> filePaths = [.. this.FileSystem.Directory.EnumerateFiles(directoryPath)];
 
         // Classify the files
-        IReadOnlyList<FileClassificationItem> classifiedFiles = filePaths
-            .Select(x => new FileClassificationItem(x, this.fileClassifier.ClassifyFile(x)))
-            .ToArray();
+        IReadOnlyList<FileClassificationItem> classifiedFiles =
+            [.. filePaths.Select(x => new FileClassificationItem(x, this.fileClassifier.ClassifyFile(x)))];
 
         if (classifiedFiles.Any(x => x.Classification == FileClassification.Other))
         {

--- a/src/StartMenuCleaner/Cleaners/Directory/SingleAppDirectoryCleaner.cs
+++ b/src/StartMenuCleaner/Cleaners/Directory/SingleAppDirectoryCleaner.cs
@@ -41,9 +41,7 @@ internal class SingleAppDirectoryCleaner : DirectoryCleanerBase
             return false;
         }
 
-        string[] filePaths = this.FileSystem.Directory
-            .EnumerateFiles(directoryPath)
-            .ToArray();
+        string[] filePaths = [.. this.FileSystem.Directory.EnumerateFiles(directoryPath)];
 
         if (filePaths.Length != 1)
         {

--- a/src/StartMenuCleaner/Utils/StartMenuHelper.cs
+++ b/src/StartMenuCleaner/Utils/StartMenuHelper.cs
@@ -18,7 +18,5 @@ internal static class StartMenuHelper
     /// </summary>
     /// <returns>An <see cref="IEnumerable{T}"/> of <see cref="string"/>.</returns>
     public static IReadOnlyList<string> GetKnownStartMenuProgramsFolders() =>
-        GetKnownStartMenuFolders()
-            .Select(x => Path.Combine(x, programsFolderName))
-            .ToArray();
+        [.. GetKnownStartMenuFolders().Select(x => Path.Combine(x, programsFolderName))];
 }

--- a/test/StartMenuCleaner.TestLibrary/MockFileSystemComposer.cs
+++ b/test/StartMenuCleaner.TestLibrary/MockFileSystemComposer.cs
@@ -27,7 +27,7 @@ internal class MockFileSystemComposer
     /// </summary>
     public MockFileSystemComposer()
     {
-        this.defaultFileSystemNodes = this.FileSystem.AllNodes.ToArray();
+        this.defaultFileSystemNodes = [.. this.FileSystem.AllNodes];
     }
 
     /// <summary>


### PR DESCRIPTION
- Updated to 9.0.200 .NET SDK
- Enabled automated .NET SDK updates from Dependabot
- Fixed 9.0.200 related analyzer updates
- Changed `rollForward` to `latestPatch` to prevent SDK breaking changes until upgrade