### PR TITLE
Remove obsolete API usage

### DIFF
--- a/test/StartMenuCleaner.TestLibrary/EmbeddedResourceHelper.cs
+++ b/test/StartMenuCleaner.TestLibrary/EmbeddedResourceHelper.cs
@@ -6,6 +6,8 @@ using System.IO;
 using System.IO.Abstractions;
 using System.Reflection;
 
+using StartMenuCleaner.TestLibrary.Extensions;
+
 /// <summary>
 /// Class EmbeddedResourceHelper.
 /// </summary>
@@ -86,7 +88,7 @@ public class EmbeddedResourceHelper
     /// <returns><see cref="string"/>.</returns>
     public string CopyToTempFile(string embeddedResourcePath)
     {
-        string temporaryFileName = this.fileSystem.Path.GetTempFileName();
+        string temporaryFileName = this.fileSystem.Path.GetTemporaryFilePath();
 
         try
         {

--- a/test/StartMenuCleaner.TestLibrary/Extensions/FileSystemExtensions.cs
+++ b/test/StartMenuCleaner.TestLibrary/Extensions/FileSystemExtensions.cs
@@ -1,0 +1,25 @@
+﻿namespace StartMenuCleaner.TestLibrary.Extensions;
+
+using System.IO.Abstractions;
+
+/// <summary>
+/// Extensions for the <see cref="IFileSystem"/> interface.
+/// </summary>
+public static class FileSystemExtensions
+{
+    /// <summary>
+    /// Gets a temporary file path.
+    /// </summary>
+    /// <param name="path">The file system path object.</param>
+    /// <returns>A temporary file path.</returns>
+    public static string GetTemporaryFilePath(this IPath path)
+    {
+        ArgumentNullException.ThrowIfNull(path);
+
+        string temporaryFilePath = path.Combine(path.GetTempPath(), path.GetRandomFileName());
+
+        path.FileSystem.File.Create(temporaryFilePath).Dispose();
+
+        return temporaryFilePath;
+    }
+}


### PR DESCRIPTION
The `IPath.GetTempFileName` method has been marked obsolete in an upcoming release.